### PR TITLE
Migrate to Typescript 3.8 (only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   },
   "dependencies": {
     "i18next": "^17.0.18",
-    "tslib": "1.9.0",
     "@types/whatwg-streams": "0.0.4",
     "@types/whatwg-fetch": "0.0.33",
     "@types/handlebars": "4.0.33"
@@ -59,11 +58,14 @@
   "devDependencies": {
     "@types/jasmine": "2.5.47",
     "awesome-typescript-loader": "3.1.2",
+    "cache-loader": "1.2.0",
     "css-loader": "0.28.0",
     "extract-loader": "0.1.0",
     "extract-text-webpack-plugin": "2.1.0",
     "file-loader": "0.11.1",
+    "fork-ts-checker-webpack-plugin": "0.4.1",
     "html-loader": "0.4.5",
+    "ifdef-loader": "2.0.0",
     "imports-loader": "0.7.1",
     "jasmine": "2.5.3",
     "json-loader": "0.5.4",
@@ -74,23 +76,20 @@
     "karma-junit-reporter": "2.0.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "2.0.3",
-    "mkdirp": "0.5.1",
+    "mkdirp": "^1.0.3",
     "node-sass": "^4.12.0",
     "null-loader": "0.1.1",
     "raw-loader": "0.5.1",
     "sass-loader": "6.0.7",
     "style-loader": "0.16.1",
-    "tslib": "1.9.0",
+    "thread-loader": "1.1.2",
+    "ts-loader": "4.0.1",
+    "tslib": "~1.10.0",
     "tslint": "5.9.1",
-    "typedoc": "0.11.1",
-    "typescript": "2.8.1",
+    "typedoc": "~0.16.9",
+    "typescript": "~3.8.1-rc",
     "url-loader": "0.5.8",
     "webpack": "2.3.3",
-    "webpack-dev-server": "2.4.2",
-    "cache-loader": "1.2.0",
-    "ifdef-loader": "2.0.0",
-    "fork-ts-checker-webpack-plugin": "0.4.1",
-    "thread-loader": "1.1.2",
-    "ts-loader": "4.0.1"
+    "webpack-dev-server": "2.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "extract-loader": "0.1.0",
     "extract-text-webpack-plugin": "2.1.0",
     "file-loader": "0.11.1",
-    "fork-ts-checker-webpack-plugin": "0.4.1",
+    "fork-ts-checker-webpack-plugin": "0.4.4",
     "html-loader": "0.4.5",
     "ifdef-loader": "2.0.0",
     "imports-loader": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -84,10 +84,10 @@
     "style-loader": "0.16.1",
     "thread-loader": "1.1.2",
     "ts-loader": "4.0.1",
-    "tslib": "~1.10.0",
+    "tslib": "~1.11.0",
     "tslint": "5.9.1",
     "typedoc": "~0.16.9",
-    "typescript": "~3.8.1-rc",
+    "typescript": "~3.8.2",
     "url-loader": "0.5.8",
     "webpack": "2.3.3",
     "webpack-dev-server": "2.4.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -339,7 +339,7 @@ export function debounce(this: any, callback: () => void, timeToDelay = 100) {
       tm = -1;
     }
     args.unshift(this);
-    tm = setTimeout(callback.bind.apply(callback, args), timeToDelay);
+    tm = self.setTimeout(callback.bind.apply(callback, args), timeToDelay);
   };
 }
 

--- a/src/range/Range1D.ts
+++ b/src/range/Range1D.ts
@@ -328,7 +328,7 @@ export default class Range1D {
    * @return {*}
    */
   indexOf(): any {
-    if (arguments[0] instanceof Range) {
+    if (arguments[0] instanceof Range1D) {
       return this.indexRangeOf(arguments[0], arguments[1]);
     }
     let arr: number[];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "module": "es6",
     "target": "es5",
     "downlevelIteration": true, // required as long as target is `es5`
-
     "importHelpers": true,
     "sourceMap": true,
     "moduleResolution": "node",
@@ -18,7 +17,6 @@
     "baseUrl": "../",
     "noImplicitAny": false,
     "skipLibCheck": true,
-
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true // required for i18next
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "module": "es6",
     "target": "es5",
+    "downlevelIteration": true, // required as long as target is `es5`
+
     "importHelpers": true,
     "sourceMap": true,
     "moduleResolution": "node",
@@ -18,7 +20,7 @@
     "skipLibCheck": true,
 
     "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true // required for i18next
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
### Summary

* Update npm dependencies
  - typescript@~3.8.1-rc
  - tslib@~1.10.0
  - tsdoc@~0.16.9
  - mkdirp@^1.0.3
* Add `downlevelIteration` to tsconfig.json
* Add `self` to `setTimeout`
* Bugfix for Range1D.indexOf()

**Note:** This PR does **not** update tslint/eslint and other unnecessary dependencies for Typescript!