### PR TITLE
Change provenance graph default permission to `ALL_NONE_NONE`

### DIFF
--- a/dist/provenance/LocalStorageProvenanceGraphManager.d.ts
+++ b/dist/provenance/LocalStorageProvenanceGraphManager.d.ts
@@ -17,7 +17,7 @@ export interface ILocalStorageProvenanceGraphManagerOptions extends ICommonProve
     prefix?: string;
     /**
      * Default permissions for new graphs.
-     * @default ALL_READ_NONE
+     * @default ALL_NONE_NONE
      */
     defaultPermission?: number;
 }

--- a/dist/provenance/LocalStorageProvenanceGraphManager.js
+++ b/dist/provenance/LocalStorageProvenanceGraphManager.js
@@ -15,7 +15,7 @@ export class LocalStorageProvenanceGraphManager {
             storage: localStorage,
             prefix: 'clue',
             application: 'unknown',
-            defaultPermission: Permission.ALL_READ_NONE
+            defaultPermission: Permission.ALL_NONE_NONE
         };
         BaseUtils.mixin(this.options, options);
     }

--- a/src/provenance/LocalStorageProvenanceGraphManager.ts
+++ b/src/provenance/LocalStorageProvenanceGraphManager.ts
@@ -29,7 +29,7 @@ export interface ILocalStorageProvenanceGraphManagerOptions extends ICommonProve
 
   /**
    * Default permissions for new graphs.
-   * @default ALL_READ_NONE
+   * @default ALL_NONE_NONE
    */
   defaultPermission?: number;
 }
@@ -39,7 +39,7 @@ export class LocalStorageProvenanceGraphManager implements IProvenanceGraphManag
     storage: localStorage,
     prefix: 'clue',
     application: 'unknown',
-    defaultPermission: Permission.ALL_READ_NONE
+    defaultPermission: Permission.ALL_NONE_NONE
   };
 
   constructor(options: ILocalStorageProvenanceGraphManagerOptions = {}) {


### PR DESCRIPTION
Closes https://github.com/datavisyn/tdp_core/issues/560

Related PR https://github.com/datavisyn/tdp_core/pull/561

### Summary

* Change from `ALL_READ_NONE` to `ALL_NONE_NONE` which means that groups don't have read access by default anymore
* Applies to all new local provenance graphs